### PR TITLE
BREAKING: slideBy prop

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -131,6 +131,8 @@ class Slider extends Component {
     window.localStorage.setItem('react-track', JSON.stringify(this.state))
   }
 
+  handleAfterSlide = (currentSlide) => { this.setState({ currentSlide }) }
+
   setRef = (name) => (ref) => { this[name] = ref }
   setStateFromInput = (propName) => ({ target }) => {
     const { checked, type } = target
@@ -194,11 +196,14 @@ class Slider extends Component {
           <this.Control label="slideTo" type="number" name="slideTo" />
           <this.Control label="startAt" type="number" name="startAt" />
           <this.Control label="visibleSlides" type="number" name="visibleSlides" />
+          <h1>Current Slide is {this.state.currentSlide}</h1>
         </div>
         { mount
         ? <div className="slider">
           <Track
-            afterSlide={afterSlide}
+            afterSlide={(idx) => {
+              this.handleAfterSlide(idx)
+            }}
             animationDuration={animationDuration}
             beforeSlide={beforeSlide}
             className={className}
@@ -212,6 +217,7 @@ class Slider extends Component {
             slideBy={slideBy}
             slideClass={slideClass}
             slideTo={slideTo}
+            slideToCenter
             startAt={startAt}
             visibleSlides={visibleSlides}
             >{ children }</Track>
@@ -304,7 +310,7 @@ render((
       <h1>react-track</h1>
       <p>A carousel-like component for react</p>
     </header>
-    <Slider startAt={5}>
+    <Slider>
       {slides.map(({ src, height, width, joiner, text }, i) => (
         <figure className="mySlide" key={`${src}-${i}`}>
           {src && <img alt="Place Zombie" src={`${src}/${width}${joiner}${height}?${i}`} />}

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,12 @@ export const hasOngoingInteraction = (el) => {
   return () => getOngoingTouchCount() || getOngoingMouseClick()
 }
 
+export const isWhollyInView = (parent) => (child = { getBoundingClientRect: () => ({}) }) => {
+  const { left: cLeft, right: cRight } = child.getBoundingClientRect()
+  const { left: pLeft, right: pRight } = parent.getBoundingClientRect()
+  return (cLeft >= pLeft && cRight <= pRight)
+}
+
 export const animate = (el, {
   delta = 0,
   immediate = false,


### PR DESCRIPTION
changes how next/prev work when slideBy is not set from defaulting to 1 to defaulting to the slide after/before the last fully visible slide.