### PR TITLE
Do not fire beforeSlide, if it is the slide we are starting on

### DIFF
--- a/src/track/track.js
+++ b/src/track/track.js
@@ -242,7 +242,9 @@ export default class Track extends Component {
     const slideIndex = normalizeIndex(index, this.childCount, infinite)
     const startingIndex = this.state.activeIndex
     const delta = children[slideIndex].offsetLeft - scrollLeft
-    beforeSlide(index)
+    if (startingIndex !== slideIndex) {
+      beforeSlide(index)
+    }
     this.setState({ isAnimating: true, activeIndex: slideIndex })
     return (new Promise((res, rej) => {
       if (immediate) {


### PR DESCRIPTION
* As a consumer, I might want to do something for setup on before and after swipe. The current implementation had it only firing the before event on initialization. The afterSlide event only fires if the slidesChanged. This PR does the same for the beforeSlide event.
